### PR TITLE
修复容器镜像构建异常

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:6 as frontend
+FROM node:10 as frontend
 COPY ./Frontend /usr/src/Frontend
 WORKDIR /usr/src/Frontend
-RUN npm install && \
+RUN npm --registry https://registry.npmmirror.com install && \
     npm run build
 
-FROM php:7.2-cli
+FROM php:7.4-cli
 COPY ./AoiAWD /usr/src/AoiAWD
 WORKDIR /usr/src/AoiAWD
-RUN pecl install mongodb && \
+RUN pecl install -D 'enable-mongodb-developer-flags="no" enable-mongodb-coverage="no" with-mongodb-system-libs="no" with-mongodb-client-side-encryption="auto" with-mongodb-snappy="auto" with-mongodb-zlib="auto" with-mongodb-zstd="auto" with-mongodb-sasl="auto" with-mongodb-ssl="auto" enable-mongodb-crypto-system-profile="no" with-mongodb-utf8proc="bundled"' mongodb && \
     docker-php-ext-enable mongodb && \
     mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
     echo "phar.readonly=Off" > "$PHP_INI_DIR/conf.d/phar.ini" && \


### PR DESCRIPTION
变动如下：

1. 前端构建的基础镜像改为 `node:10`
2. 后端的基础镜像改为 `php:7.4-cli`
3. 使用 pecl 安装 mongo 扩展时显式指定参数（默认值）
